### PR TITLE
Fix Variable notation, deprecation warning.

### DIFF
--- a/src/Composer/MuLoaderPlugin.php
+++ b/src/Composer/MuLoaderPlugin.php
@@ -198,7 +198,7 @@ class MuLoaderPlugin implements PluginInterface, EventSubscriberInterface
             file_put_contents(
                 $muPath . $muRequireFile,
                 // Need to break up __DIR__ to stop this https://github.com/composer/composer/blob/32966a3b1d48bc01472a8321fd6472b44fad033a/src/Composer/Plugin/PluginManager.php#L193 occurring.
-                "<?php\n" . $this->getMuRequireGeneratedDocBlock() . "\n" . 'require_once __DI' . 'R__ . ' . "'${toLoader}';\n"
+                "<?php\n" . $this->getMuRequireGeneratedDocBlock() . "\n" . 'require_once __DI' . 'R__ . ' . "'{$toLoader}';\n"
             );
         }
     }


### PR DESCRIPTION
Error during composer install:

Deprecation Notice: Using ${var} in strings is deprecated, use {$var} instead in /Users/rmpel/Development/asc2023/app/vendor/acato-plugins/wp-muplugin-loader/src/Composer/MuLoaderPlugin.php:201